### PR TITLE
added multiple hub-height options into spec file for EWT_DW54_900kW_54

### DIFF
--- a/turbine_models/specs/Distributed/EWT_DW54_900kW_54.yaml
+++ b/turbine_models/specs/Distributed/EWT_DW54_900kW_54.yaml
@@ -5,7 +5,7 @@ rated_wind_speed: 13.5 #m/s
 cut_in_wind_speed: 2.5 #m/s
 cut_out_wind_speed: 25 #m/s
 rotor_diameter: 54 #m
-hub_height: 40 #m (can be 40,50 or 75m)
+hub_height: [40.0, 50.0, 75.0] #m (can be 40,50 or 75m)
 drivetrain: synchronous multi-pole #N/A
 control: pitch-controlled #N/A
 iec_class: III-A #N/A


### PR DESCRIPTION
added all possible hub-height options to `turbine_models/specs/Distributed/EWT_DW54_900kW_54.yaml` - only included one of the three options before.