### PR TITLE
Patch: Python compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,14 @@ maintainers = [
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
 description = "Retrieves power curves and key data for commonly used turbine models in industry and R&D community."
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10, <3.14"
 license = {file = "LICENSE"}
 dependencies = [
     "numpy",
     "pandas",
-    "dill",
     "matplotlib",
-    "pyyaml-include <= 1.4.1",
+    "pyyaml",
+    "pyyaml-include",
 ]
 keywords = [
     "python3",
@@ -46,6 +46,10 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/turbine_models/__init__.py
+++ b/turbine_models/__init__.py
@@ -2,4 +2,4 @@
 """NREL Turbine Models."""
 from .parser import Turbines
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/turbine_models/make_turbine_data_summary.py
+++ b/turbine_models/make_turbine_data_summary.py
@@ -1,8 +1,10 @@
-from turbine_models.parser import Turbines
-import pandas as pd
-import turbine_models
 import os
+
 import yaml
+import pandas as pd
+
+import turbine_models
+from turbine_models.parser import Turbines
 
 def write_yaml(filename,data):
     if not '.yaml' in filename:

--- a/turbine_models/parser.py
+++ b/turbine_models/parser.py
@@ -7,17 +7,14 @@ Created on Wed Apr 21 14:12:17 2021
 """
 import os
 import sys
+import importlib.resources as importlib_resources
 
-if sys.version_info < (3, 9):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
-
-import matplotlib.pyplot as plt
+import yaml
 import numpy as np
 import pandas as pd
+import matplotlib.pyplot as plt
+
 import turbine_models
-import yaml
 from turbine_models.turbine_spell_checker_tools import get_best_match_turbine_in_library
 
 class Turbines:


### PR DESCRIPTION
This PR updates the allowable Python version from 3.10 & 3.11 to 3.10 through 3.13, and cleans up the dependency stack for less-strict  versioning and only the relevant packages.