### PR TITLE
Update `os` Usage in Examples.

### DIFF
--- a/examples/02-make_turbine_data_summary.py
+++ b/examples/02-make_turbine_data_summary.py
@@ -1,8 +1,9 @@
-from turbine_models.make_turbine_data_summary import create_turbine_data_summary
-import os
+from pathlib import Path
 
-output_dir = os.path.dirname(__file__,"outputs")
-if not os.path.isdir(output_dir):
-    os.makedirs(output_dir)
+from turbine_models.make_turbine_data_summary import create_turbine_data_summary
+
+output_dir = Path(__file__).parent / "outputs"
+if not output_dir.is_dir():
+    output_dir.mkdir(parents=True)
 
 create_turbine_data_summary(output_dir)


### PR DESCRIPTION
This PR addresses an issue where the usage of `os.path.dirname()` has changed by replacing `os` with the preferred `pathlib` library for modern path management.

Resolves #23 