### PR TITLE
Bugfix: Minor error in `check_turbine_library_for_turbine`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Version 0.2.1, Nov 26, 2025
+* bugfix in `check_turbine_library_for_turbine()` method if `turbine_group` is input as "none" and turbine does not exist in the turbine-models library.
+
 ## Version 0.2.0, Nov 19, 2025
 * added power curve estimation tools
 * added methods to get turbine model specs formatted for PySAM or FLORIS

--- a/turbine_models/__init__.py
+++ b/turbine_models/__init__.py
@@ -2,4 +2,4 @@
 """NREL Turbine Models."""
 from .parser import Turbines
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/turbine_models/tools/library_tools.py
+++ b/turbine_models/tools/library_tools.py
@@ -24,6 +24,7 @@ def check_turbine_library_for_turbine(turbine_name:str, turbine_group = "none") 
             if any(turb.lower()==turbine_name.lower() for turb in turbines_in_group.values()):
                 valid_name = True
                 return valid_name
+        return False
 
     turbines_in_group = t_lib.turbines(group = turbine_group)
     if any(turb.lower()==turbine_name.lower() for turb in turbines_in_group.values()):


### PR DESCRIPTION
Bugfix in `check_turbine_library_for_turbine()` method found in `turbine_models/tools/library_tools.py`. If the `turbine_group` is input as "none" and the turbine does not exist, rather than return False, the code went to the following line:

```python
turbines_in_group = t_lib.turbines(group = turbine_group) 
```
which throws an error because `turbine_group` is "none".

Bug fixed by adding a `return False` statement within the `if turbine_group not in t_lib.groups` block.