### PR TITLE
Updated GitHub Files for Lab Name Change

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Usage question
-    url: https://github.com/NREL/turbine-models/discussions
+    url: https://github.com/NatLabRockies/turbine-models/discussions
     about: Have any questions about using turbine-models? Post in Discussions to engage with the NREL team and turbine-models community.

--- a/.github/ISSUE_TEMPLATE/turbine_request.yml
+++ b/.github/ISSUE_TEMPLATE/turbine_request.yml
@@ -20,7 +20,7 @@ body:
 
       Please also **update the issue title** as well.
     value: |
-      `OEM_MODEL_POWER_ROTOR_DIAMETER`: https://github.com/NREL/turbine-models
+      `OEM_MODEL_POWER_ROTOR_DIAMETER`: https://github.com/NatLabRockies/turbine-models
   validations:
     required: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Getting started
 
 These contributing guidelines should be read by anyone wishing to contribute code, 
-turbines, or documentation changes into the NREL turbine-models library.
+turbines, or documentation changes into the NLR turbine-models library.
 
 1. Create a fork of turbine-models on GitHub
 2. Clone your fork of the repository
@@ -24,9 +24,9 @@ turbines, or documentation changes into the NREL turbine-models library.
     pip install -e ".[dev,docs]"
     ```
 
-## Keeping your fork in sync with NREL/turbine-models
+## Keeping your fork in sync with NatLabRockies/turbine-models
 
-The "main" turbine-models repository is regularly updated with ongoing research at NREL
+The "main" turbine-models repository is regularly updated with ongoing research at NLR
 and beyond. After creating and cloning your fork from the previous section, you will
 want to keep it up to date with the latest improvements.
 
@@ -41,14 +41,14 @@ inevitably arise in development work.
    cd /your/path/to/turbine-models/
    ```
 
-2. If you haven't already, add NREL/turbine-models as the "upstream" location (or whichever naming
+2. If you haven't already, add NatLabRockies/turbine-models as the "upstream" location (or whichever naming
    convention you prefer).
 
    ```bash
-   git remote add upstream https://github.com/NREL/turbine-models.git
+   git remote add upstream https://github.com/NatLabRockies/turbine-models.git
    ```
 
-   To find the name you've given NREL/turbine-models again, you can simply run the following to display
+   To find the name you've given NatLabRockies/turbine-models again, you can simply run the following to display
    all the remote sources you're tracking.
 
    ```bash
@@ -61,7 +61,7 @@ inevitably arise in development work.
    git fetch --all
    ```
 
-4. Sync the upstream (NREL) changes
+4. Sync the upstream (NLR) changes
 
    ```bash
    git checkout main
@@ -89,9 +89,9 @@ release. The following steps will outline this process, including if anything go
 wrong.
 
 1. Bump the version by the appropriate major, minor, or patch version in
-   [`turbine_models/__init__.py`](https://github.com/NREL/turbine-models/blob/main/turbine_models/__init__.py).
+   [`turbine_models/__init__.py`](https://github.com/NatLabRockies/turbine-models/blob/main/turbine_models/__init__.py).
 2. Date-stamp the unreleased version in
-   [`RELEASE.md`](https://github.com/NREL/turbine-models/blob/main/RELEASE.md), and
+   [`RELEASE.md`](https://github.com/NatLabRockies/turbine-models/blob/main/RELEASE.md), and
    ensure the version matches the version used in step 1.
 3. Stage, commit, and push the changes.
 4. Tag the new version: `git tag -a v1.2.3 -m "Tag message for v1.2.3"`.
@@ -104,7 +104,7 @@ wrong.
    2. Address the build or publishing errors in the GitHub Action.
    3. Repeat the process starting back to step 3 in the main instructions.
 7. Create a new release with release notes, using the new tag at
-   https://github.com/NREL/turbine-models/releases/new. Once published, this will
+   https://github.com/NatLabRockies/turbine-models/releases/new. Once published, this will
    trigger the `.github/workflows/publish_to_pypi.yml` GitHub Action that publishes
    the new release on PyPI. If this is unsuccessful, follow the substeps for step 6,
    except that you will be unable to republish to Test PyPI because PyPI and Test PyPI

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# NREL Wind Turbine Power Curve Archive
+# NLR Wind Turbine Power Curve Archive
 
 [![PyPI version](https://badge.fury.io/py/turbine-models.svg)](https://badge.fury.io/py/turbine-models)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![docs - GitHub Pages](https://img.shields.io/badge/docs-GitHub_Pages-blue)](https://nrel.github.io/turbine-models/)
+[![docs - GitHub Pages](https://img.shields.io/badge/docs-GitHub_Pages-blue)](https://natlabrockies.github.io/turbine-models/)
 [![DOI 10.11578/dc.20210112.1](https://img.shields.io/badge/DOI-10.11578/dc.20210112.1-brightgreen?link=https://doi.org/10.11578/dc.20210112.1)](https://doi.org/10.11578/dc.20210112.1)
 
 ## Welcome to the repository for the wind turbine power curve archive.
@@ -24,7 +24,7 @@ Here you can find .csv files with the following turbine data:
 
 ## Documentation
 Each turbine included in the repository is documented in detail:
-https://nrel.github.io/turbine-models/
+https://natlabrockies.github.io/turbine-models/
 
 The name of the turbine on the .csv file with tabular data should match up with a corresponding documentation page.
 
@@ -41,7 +41,7 @@ pip install turbine-models
 1. Using Git, navigate to a local target directory and clone repository:
 
     ```bash
-    git clone https://github.com/NREL/turbine-models.git
+    git clone https://github.com/NatLabRockies/turbine-models.git
     ```
 
 2. Navigate to `turbine-models`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Unreleased, TBD
+## Version 0.2.2, April 3, 2026
 * Updated links for lab name change (renamed from NREL to NLR or NatLabRockies)
 
 ## Version 0.2.1, Nov 26, 2025

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Unreleased, TBD
+* Updated links for lab name change (renamed from NREL to NLR or NatLabRockies)
+
 ## Version 0.2.1, Nov 26, 2025
 * bugfix in `check_turbine_library_for_turbine()` method if `turbine_group` is input as "none" and turbine does not exist in the turbine-models library.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "turbine-models"
 dynamic = ["version"]
 authors = [
-    {name = "Patrick Duffy", email = "patrick.duffy@nrel.gov"},
+    {name = "Patrick Duffy", email = "patrick.duffy@nlr.gov"},
     {name = "Travis Williams"},
 ]
 maintainers = [
-    {name = "Patrick Duffy", email = "patrick.duffy@nrel.gov"},
-    {name = "Elenya Grant", email = "elenya.grant@nrel.gov"},
-    {name = "Rob Hammond", email = "rob.hammond@nrel.gov"},
+    {name = "Patrick Duffy", email = "patrick.duffy@nlr.gov"},
+    {name = "Elenya Grant", email = "elenya.grant@nlr.gov"},
+    {name = "Rob Hammond", email = "rob.hammond@nlr.gov"},
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
 description = "Retrieves power curves and key data for commonly used turbine models in industry and R&D community."
@@ -57,10 +57,10 @@ classifiers = [
 ]
 
 [project.urls]
-source = "https://github.com/NREL/turbine-models"
-documentation = "https://nrel.github.io/turbine-models/"
-issues = "https://github.com/NREL/turbine-models/issues"
-changelog = "https://github.com/NREL/turbine-models/blob/main/RELEASE.md"
+source = "https://github.com/NatLabRockies/turbine-models"
+documentation = "https://natlabrockies.github.io/turbine-models/"
+issues = "https://github.com/NatLabRockies/turbine-models/issues"
+changelog = "https://github.com/NatLabRockies/turbine-models/blob/main/RELEASE.md"
 
 [project.optional-dependencies]
 develop = [

--- a/turbine_models/__init__.py
+++ b/turbine_models/__init__.py
@@ -2,4 +2,4 @@
 """NREL Turbine Models."""
 from .parser import Turbines
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
# Updated GitHub Files for Lab Name Change

Updated links for documentation pages, maintainer email addresses, and links to repository to reflect the lab name change from NREL to NLR (National Laboratory of the Rockies). The turbines with NREL in the name have not been updated in this PR - assuming that it may result in breaking changes for any repositories that use package. 